### PR TITLE
WIP: Add sevctl package

### DIFF
--- a/sevctl/sevctl.spec
+++ b/sevctl/sevctl.spec
@@ -1,0 +1,41 @@
+%global debug_package %{nil}
+
+
+Name:          sevctl
+Version:       0.1.0
+Release:       1%{?dist}
+Summary:       Administrative utility for AMD SEV
+License:       Apache-2.0
+URL:           https://github.com/enarx/%{name}
+ExclusiveArch: x86_64
+BuildRequires: cargo, openssl-devel
+# FIXME:
+# Source0: https://github.com/enarx/sevctl/archive/v%{version}.tar.gz
+Source0: %{name}-%{version}.tar.gz
+
+
+%description
+Administrative utility for AMD SEV
+
+
+%prep
+%setup -q
+
+
+%build
+cargo build --release
+
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+install -m 0755 target/release/sevctl %{buildroot}/usr/bin/sevctl
+
+
+%files
+/usr/bin/sevctl
+
+
+%changelog
+* Wed Dec 02 2020 Connor Kuehl <ckuehl@redhat.com> - 0.1.0-1
+  - Initial sevctl package
+


### PR DESCRIPTION
Related: https://github.com/enarx/enarx/issues/535

Drafted until:

- [ ] ~~`sevctl` release minted on crates.io~~ actually I think this is only required for _library_ crates.
- [ ] `sevctl` tagged release on GitHub repo so spec file can download from a URL instead of using a local source

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

This is building for f31 - rawhide. CentOS (I assumed was the closest chroot to RHEL) FTBFS due to an old Rust toolchain, but I'm seeing what I can do to work through that.